### PR TITLE
Feat: change-user-photo and change-company-photo endpoints

### DIFF
--- a/app/api/routes/company.py
+++ b/app/api/routes/company.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Request, Body
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Body, UploadFile, File
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from typing import Annotated
@@ -14,7 +14,8 @@ from app.utils.company_crud import (
     get_strengths_by_company_id,
     get_weakness_by_company_id,
     get_significant_strengths_weakness,
-    get_org_growth_percentages)
+    get_org_growth_percentages,
+    update_company_photo)
 
 from app.utils.users_crud import (
     create_user_in_dashboard,
@@ -23,11 +24,14 @@ from app.utils.users_crud import (
 from uuid import uuid4
 from typing import Optional, List
 from app.email.send_reset_password import send_reset_password
-from firebase_admin import auth, credentials
+from firebase_admin import auth, credentials, storage
 from firebase_admin.exceptions import FirebaseError
+import os
 
 db_dependency = Annotated[Session, Depends(get_db)]
 router = APIRouter(prefix="/company", tags=["company"])
+
+bucket = storage.bucket()
 
 @router.post("/create-company")
 async def create_company_endpoint(
@@ -624,3 +628,77 @@ async def org_growth_percentages_endpoint(request: Request, db: db_dependency):
     return response
   except Exception as error:
     raise HTTPException(status_code=400, detail=str(error))
+  
+@router.post("/change-company-photo")
+async def change_company_photo(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    request: Request = None
+):
+    """
+    Changes the company photo uploaded by a user and stores it in Firebase Storage
+
+    Args:
+        file: The uploaded image file.
+        request: The request object containing the user token.
+
+    Returns:
+        dict: A JSON response with a success message and the new photo URL.
+    
+    Example Response:
+        {
+            "message": "Company photo successfully updated for {user_id}",
+            "photo_url": "https://firebasestorage.googleapis.com/..."
+        }
+    """
+    # Auth part, get the current user
+    auth_header = request.headers.get("Authorization")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Authorization header is missing")
+    id_token = auth_header.split(" ")[1]
+    try:
+        decoded_token = auth.verify_id_token(id_token)
+        current_user_id = decoded_token['uid']
+    except Exception as e:
+        raise HTTPException(status_code=401, detail="Invalid authentication token")
+
+    # Get the current user from the database
+    current_user = db.query(Users).filter(Users.id == current_user_id).first()
+    if not current_user:
+        raise HTTPException(status_code=400, detail="Current user not found")
+
+    try:
+        # Generate a unique filename
+        file_extension = os.path.splitext(file.filename)[1]
+        new_filename = f"company_photos/{current_user_id}/photo_{uuid4()}{file_extension}"
+
+        # Upload the file to Firebase Storage
+        blob = bucket.blob(new_filename)
+        blob.upload_from_file(file.file)
+
+        # Make the blob publicly accessible
+        blob.make_public()
+
+        # Get the public URL
+        photo_url = blob.public_url
+
+        if not current_user.company_id:
+            raise HTTPException(status_code=404, detail="User is not associated with a company")
+
+        company = get_company_by_id(db=db, company_id=current_user.company_id)
+
+        if company is None:
+            raise HTTPException(status_code=404, detail="Company not found")
+
+        # Update the user's company photo URL in the database
+        update_company_photo(db=db, company_id=current_user.company_id, photo_url=photo_url)
+
+        return JSONResponse(
+            content={
+                "message": f"Company photo successfully updated for {current_user.company_id}",
+                "photo_url": photo_url
+            },
+            status_code=200
+        )
+    except Exception as error:
+        raise HTTPException(status_code=400, detail=str(error))

--- a/app/api/routes/company.py
+++ b/app/api/routes/company.py
@@ -630,11 +630,7 @@ async def org_growth_percentages_endpoint(request: Request, db: db_dependency):
     raise HTTPException(status_code=400, detail=str(error))
   
 @router.post("/change-company-photo")
-async def change_company_photo(
-    file: UploadFile = File(...),
-    db: Session = Depends(get_db),
-    request: Request = None
-):
+async def change_company_photo(file: UploadFile = File(...), db: Session = Depends(get_db), request: Request = None):
     """
     Changes the company photo uploaded by a user and stores it in Firebase Storage
 

--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -33,11 +33,11 @@ from app.email.send_reset_password import send_reset_password
 from typing import List
 from firebase_admin.exceptions import FirebaseError
 import requests
-from uuid import uuid4
-import os
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
+from uuid import uuid4
+import os
 
 db_dependency = Annotated[Session, Depends(get_db)]
 limiter = Limiter(key_func=get_remote_address)
@@ -949,9 +949,13 @@ async def edit_personal_details(data: UpdatePersonalDetailsSchema, db: db_depend
     )
   except Exception as error:
     raise HTTPException(status_code=400, detail=str(error))
-
+  
 @router.post("/change-user-photo")
-async def change_user_photo(file: UploadFile = File(...), db: Session = Depends(get_db), request: Request = None):
+async def change_user_photo(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    request: Request = None
+):
     """
     Changes the user photo uploaded by a user and stores it in cloud storage
 
@@ -1004,6 +1008,11 @@ async def change_user_photo(file: UploadFile = File(...), db: Session = Depends(
                 "message": f"User photo successfully updated for {current_user_id}",
                 "photo_url": photo_url
             },
+            status_code=200
+    )
+    except Exception as error:
+        raise HTTPException(status_code=400, detail=str(error))
+
 
 @router.post("/request-password-reset")
 @limiter.limit("1/minute")  # Apply rate limiting
@@ -1105,6 +1114,6 @@ async def update_user_type(request: Request, db: db_dependency):
         return JSONResponse(
             content={"message": f"User role set to {role}", "success": True},
             status_code=200
-        )
+            )
     except Exception as error:
         raise HTTPException(status_code=400, detail=str(error))

--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 import datetime as dt
-from fastapi import APIRouter, Depends, HTTPException, status, Request
+from fastapi import APIRouter, Depends, HTTPException, status, Request, UploadFile, File
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
-from typing import Annotated
+from typing import Annotated, Optional
 from app.firebase.session import firebase, auth
 import firebase_admin
-from firebase_admin import auth, credentials
+from firebase_admin import auth, credentials, storage
 from app.database.models import Users
 from app.schemas.models import SignUpSchema, UpdateUserSchema, LoginSchema, UserCompanyDetailsSchema,CustomTokenRequestSchema, AddUserToCompanySchema, AddUserToCompanyDashboardSchema, PasswordChangeRequest, UpdatePersonalDetailsSchema
 from app.database.connection import get_db
@@ -25,17 +25,21 @@ from app.utils.users_crud import (
     add_user_to_company_crud,
     create_user_in_dashboard,
     get_latest_sprint_for_user,
-    update_personal_details
+    update_personal_details,
+    update_user_photo
 )
 from app.utils.company_crud import get_company_by_id
 from app.email.send_reset_password import send_reset_password
 from typing import List
 from firebase_admin.exceptions import FirebaseError
 import requests
+from uuid import uuid4
+import os
 
 db_dependency = Annotated[Session, Depends(get_db)]
 router = APIRouter(prefix="/accounts", tags=["accounts"])
 firebase_auth = HTTPBearer()
+bucket = storage.bucket()
 
 @router.post("/save-company-details")
 async def save_company_details(data: UserCompanyDetailsSchema, db: db_dependency, token = Depends(verify_token)):
@@ -946,3 +950,66 @@ async def edit_personal_details(data: UpdatePersonalDetailsSchema, db: db_depend
     )
   except Exception as error:
     raise HTTPException(status_code=400, detail=str(error))
+  
+@router.post("/change-user-photo")
+async def change_user_photo(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    request: Request = None
+):
+    """
+    Changes the user photo uploaded by a user and stores it in cloud storage
+
+    Args:
+        file: The uploaded image file.
+        request: The request object containing the user token.
+
+    Returns:
+        dict: A JSON response with a success message and the new photo URL.
+    
+    Example Response:
+        {
+            "message": "User photo successfully updated for {user_id}",
+            "photo_url": "https://storage.googleapis.com/your-bucket-name/user_photos/photo_123456.jpg"
+        }
+    """
+    # Auth part, get the current user
+    auth_header = request.headers.get("Authorization")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Authorization header is missing")
+    id_token = auth_header.split(" ")[1]
+    decoded_token = auth.verify_id_token(id_token)
+    current_user_id = decoded_token.get("uid")
+
+    # Get the current user from the database
+    current_user = db.query(Users).filter(Users.id == current_user_id).first()
+    if not current_user:
+        raise HTTPException(status_code=400, detail="Current user not found")
+
+    try:
+        # Generate a unique filename
+        file_extension = os.path.splitext(file.filename)[1]
+        new_filename = f"user_photos/photo_{uuid4()}{file_extension}"
+
+        # Upload the file to Google Cloud Storage
+        blob = bucket.blob(new_filename)
+        blob.upload_from_file(file.file)
+
+        # Make the blob publicly accessible
+        blob.make_public()
+
+        # Get the public URL
+        photo_url = blob.public_url
+
+        # Update the user's photo URL in the database
+        update_user_photo(db=db, user_id=current_user_id, photo_url=photo_url)
+
+        return JSONResponse(
+            content={
+                "message": f"User photo successfully updated for {current_user_id}",
+                "photo_url": photo_url
+            },
+            status_code=200
+        )
+    except Exception as error:
+        raise HTTPException(status_code=400, detail=str(error))

--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -951,11 +951,7 @@ async def edit_personal_details(data: UpdatePersonalDetailsSchema, db: db_depend
     raise HTTPException(status_code=400, detail=str(error))
 
 @router.post("/change-user-photo")
-async def change_user_photo(
-    file: UploadFile = File(...),
-    db: Session = Depends(get_db),
-    request: Request = None
-):
+async def change_user_photo(file: UploadFile = File(...), db: Session = Depends(get_db), request: Request = None):
     """
     Changes the user photo uploaded by a user and stores it in cloud storage
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, DateTime, Float
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, DateTime, Float, LargeBinary
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 from app.database.connection import Base, engine
@@ -22,6 +22,7 @@ class Users(Base):
     is_active = Column(Boolean, default=True)
     acc_activated = Column(Boolean, default=False)
     user_type = Column(String, index=True)
+    user_photo_url = Column(String)
 
     traits = relationship('Traits', back_populates='users')
     chosen_traits = relationship('ChosenTraits', back_populates='users')
@@ -253,6 +254,7 @@ class Company(Base):
     name = Column(String, index=True)
     member_count = Column(Integer, index=True)
     admin_count = Column(Integer, index=True)
+    company_photo_url = Column(String)
 
 
 

--- a/app/utils/company_crud.py
+++ b/app/utils/company_crud.py
@@ -199,3 +199,12 @@ def get_org_growth_percentages(db: Session, company_id: str):
         'percent_effective_strength_area': result.percent_effective_strength_area if result else None,
         'percent_effective_weakness_area': result.percent_effective_weakness_area if result else None
     }
+
+def update_company_photo(db: Session, company_id: str, photo_url: str):
+    db_company = db.query(Company).filter(Company.id == company_id).first()
+
+    if db_company:
+        db_company.company_photo_url = photo_url
+        db.commit()
+
+    return db_company

--- a/app/utils/users_crud.py
+++ b/app/utils/users_crud.py
@@ -205,3 +205,12 @@ def update_personal_details(db: Session, user_id=None, email=None, first_name=No
         db.commit()
 
     return db_user
+
+def update_user_photo(db: Session, user_id: str, photo_url: str):
+    db_user = db.query(Users).filter(Users.id == user_id).first()
+
+    if db_user:
+        db_user.user_photo_url = photo_url
+        db.commit()
+
+    return db_user


### PR DESCRIPTION
# Settings Page Endpoints
Below are the endpoints included in the pull request
- change-company-photo
- change-user-photo

## Prerequisites
- Ensure that the user used to login has a company_id value in the users table

## Endpoints 1 and 2: change-company-photo and change-user-photo
Changes the company or user photo based on an input photo file and the company_id or user_id associated to the user token

Example Response: 
```
        {
            "message": "User photo successfully updated for {user_id}",
            "photo_url": "https://storage.googleapis.com/your-bucket-name/user_photos/photo_123456.jpg"
        }
```
